### PR TITLE
SWIP-478 Overwrite breadcrumb with GDS version

### DIFF
--- a/govuk/templates/core/navbar.mustache
+++ b/govuk/templates/core/navbar.mustache
@@ -67,7 +67,7 @@
     <ol class="govuk-breadcrumbs__list">{{!
         }}{{#get_items}}
             {{#has_action}}
-                <li class="govuk-breadcrumbs__list-item{{#is_hidden}} dimmed_text{{/is_hidden}}">
+                <li class="govuk-breadcrumbs__list-item">
                     <a href="{{{action}}}"
                         class="govuk-breadcrumbs__link"
                         {{#is_last}}aria-current="page"{{/is_last}}
@@ -79,7 +79,7 @@
                 </li>
             {{/has_action}}
             {{^has_action}}
-                <li class="govuk-breadcrumbs__list-item{{#is_hidden}} dimmed_text{{/is_hidden}}">
+                <li class="govuk-breadcrumbs__list-item">
                     <span {{#attributes}}{{name}}="{{value}}" {{/attributes}}>
                         {{{text}}}
                     </span>

--- a/govuk/templates/core/navbar.mustache
+++ b/govuk/templates/core/navbar.mustache
@@ -1,0 +1,90 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/navbar
+
+    Navbar template.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * get_items - array of items
+      * has_action - boolean
+      * action - string
+      * get_title - string
+      * get_content - string
+      * is_hidden - boolean
+
+    Example context (json):
+    {
+        "get_items": [
+            {
+                "has_action": true,
+                "action": "#",
+                "get_title": "Test title",
+                "get_content": "First & fresh",
+                "is_hidden": false
+            },
+            {
+                "has_action": true,
+                "action": "#",
+                "get_title": "Second item & a title",
+                "get_content": "Second item",
+                "is_hidden": false
+            },
+            {
+                "has_action": false,
+                "get_content": "Third item",
+                "is_hidden": false
+            },
+            {
+                "has_action": false,
+                "get_content": "Fourth & last",
+                "is_hidden": true
+            }
+        ]
+    }
+}}
+<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+    <ol class="govuk-breadcrumbs__list">{{!
+        }}{{#get_items}}
+            {{#has_action}}
+                <li class="govuk-breadcrumbs__list-item{{#is_hidden}} dimmed_text{{/is_hidden}}">
+                    <a href="{{{action}}}"
+                        class="govuk-breadcrumbs__link"
+                        {{#is_last}}aria-current="page"{{/is_last}}
+                        {{#get_title}}title="{{get_title}}"{{/get_title}}
+                        {{#attributes}}{{name}}="{{value}}" {{/attributes}}
+                    >
+                        {{{get_content}}}
+                    </a>
+                </li>
+            {{/has_action}}
+            {{^has_action}}
+                <li class="govuk-breadcrumbs__list-item{{#is_hidden}} dimmed_text{{/is_hidden}}">
+                    <span {{#attributes}}{{name}}="{{value}}" {{/attributes}}>
+                        {{{text}}}
+                    </span>
+                </li>
+            {{/has_action}}
+        {{/get_items}}{{!
+    }}</ol>
+</nav>


### PR DESCRIPTION
Moodle mustache template overwritten with GDS breadcrumb component. 