### PR TITLE
[SWIP-612] Restructure HTML so content is left aligned 

### DIFF
--- a/govuk/renderers.php
+++ b/govuk/renderers.php
@@ -2,6 +2,15 @@
 
 class theme_govuk_core_renderer extends core_renderer
 {
+    public function body_attributes($additionalclasses = []) {
+        $attributes = parent::body_attributes($additionalclasses);
+
+        // Add your custom class
+        $attributes = preg_replace('/class="([^"]*)"/', 'class="$1 govuk-template__body"', $attributes);
+
+        return $attributes;
+    }
+
     /**
      * See if this is the first view of the current cm in the session if it has fake blocks.
      *

--- a/govuk/templates/theme_boost/drawers.mustache
+++ b/govuk/templates/theme_boost/drawers.mustache
@@ -54,54 +54,18 @@
 <body {{{ bodyattributes }}}>
 
 <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-<!-- component HTML -->
-<script type="module" src="/theme/govuk/javascript/govuk-frontend.min.js"></script>
-<script type="module">
-    import { initAll } from '/theme/govuk/javascript/govuk-frontend.min.js'
-    initAll()
-</script>
+
+<a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+{{> theme_govuk/navbar }}
 
 {{> core/local/toast/wrapper}}
-<div id="page-wrapper" class="d-print-block">
 
-    {{{ output.standard_top_of_body_html }}}
 
-    {{> theme_govuk/navbar }}
-    {{#courseindex}}
-        {{< theme_boost/drawer }}
-            {{$id}}theme_boost-drawers-courseindex{{/id}}
-            {{$drawerheadercontent}}
-                {{> theme_boost/courseindexdrawercontrols}}
-            {{/drawerheadercontent}}
-            {{$drawerclasses}}drawer drawer-left {{#courseindexopen}}show{{/courseindexopen}}{{/drawerclasses}}
-            {{$drawercontent}}
-                {{{courseindex}}}
-            {{/drawercontent}}
-            {{$drawerpreferencename}}drawer-open-index{{/drawerpreferencename}}
-            {{$drawerstate}}show-drawer-left{{/drawerstate}}
-            {{$tooltipplacement}}right{{/tooltipplacement}}
-            {{$closebuttontext}}{{#str}}closecourseindex, core{{/str}}{{/closebuttontext}}
-        {{/ theme_boost/drawer}}
-    {{/courseindex}}
-    {{#hasblocks}}
-        {{< theme_boost/drawer }}
-            {{$id}}theme_boost-drawers-blocks{{/id}}
-            {{$drawerclasses}}drawer drawer-right{{#blockdraweropen}} show{{/blockdraweropen}}{{/drawerclasses}}
-            {{$drawercontent}}
-                <section class="d-print-none" aria-label="{{#str}}blocks{{/str}}">
-                    {{{ addblockbutton }}}
-                    {{{ sidepreblocks }}}
-                </section>
-            {{/drawercontent}}
-            {{$drawerpreferencename}}drawer-open-block{{/drawerpreferencename}}
-            {{$forceopen}}{{#forceblockdraweropen}}1{{/forceblockdraweropen}}{{/forceopen}}
-            {{$drawerstate}}show-drawer-right{{/drawerstate}}
-            {{$tooltipplacement}}left{{/tooltipplacement}}
-            {{$drawercloseonresize}}1{{/drawercloseonresize}}
-            {{$closebuttontext}}{{#str}}closeblockdrawer, core{{/str}}{{/closebuttontext}}
-        {{/ theme_boost/drawer}}
-    {{/hasblocks}}
-    <div id="page" data-region="mainpage" data-usertour="scroller" class="drawers {{#courseindexopen}}show-drawer-left{{/courseindexopen}} {{#blockdraweropen}}show-drawer-right{{/blockdraweropen}} drag-container">
+<div class="govuk-width-container">
+    <main class="govuk-main-wrapper" id="main-content">
+        {{{ output.standard_top_of_body_html }}}
+
         <div id="topofscroll" class="main-inner">
             <div class="drawer-toggles d-flex">
                 {{#courseindex}}
@@ -158,10 +122,18 @@
                 </div>
             </div>
         </div>
-    </div>
-    {{> theme_govuk/footer }}
-    {{{ output.standard_after_main_region_html }}}
+        {{{ output.standard_after_main_region_html }}}
+    </main>
 </div>
+
+{{> theme_govuk/footer }}
+
+<!-- component HTML -->
+<script type="module" src="/theme/govuk/javascript/govuk-frontend.min.js"></script>
+<script type="module">
+    import { initAll } from '/theme/govuk/javascript/govuk-frontend.min.js'
+    initAll()
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Content now sits left aligned with the govuk logo

Before
![image](https://github.com/user-attachments/assets/e3cf31c1-cd81-419e-8fc6-8ef0bb52a61e)

After
![image](https://github.com/user-attachments/assets/bcfdf746-9409-429f-811b-1dcf8218c5c9)