### PR TITLE
[SWIP-613] Fix nav styles/alignment

### DIFF
--- a/govuk/templates/theme_govuk/moremenu.mustache
+++ b/govuk/templates/theme_govuk/moremenu.mustache
@@ -52,6 +52,11 @@
     </button>
 
     <ul id="navigation" class="govuk-service-navigation__list">
+        {{#nodecollection}}
+            {{#children}}
+                {{> core/moremenu_children}}
+            {{/children}}
+        {{/nodecollection}}
         {{#nodearray}}
             {{> theme_govuk/moremenu_children}}
         {{/nodearray}}

--- a/govuk/templates/theme_govuk/moremenu.mustache
+++ b/govuk/templates/theme_govuk/moremenu.mustache
@@ -51,22 +51,10 @@
         Menu
     </button>
 
-    <ul id="moremenu-{{moremenuid}}-{{navbarstyle}}" role="{{#istablist}}tablist{{/istablist}}{{^istablist}}menubar{{/istablist}}" class="govuk-service-navigation__list">
-        {{#nodecollection}}
-            {{#children}}
-                {{> core/moremenu_children}}
-            {{/children}}
-        {{/nodecollection}}
+    <ul id="navigation" class="govuk-service-navigation__list">
         {{#nodearray}}
-            {{> core/moremenu_children}}
+            {{> theme_govuk/moremenu_children}}
         {{/nodearray}}
-        <li role="none" class="nav-item dropdown dropdownmoremenu d-none" data-region="morebutton">
-            <a class="dropdown-toggle nav-link {{#isactive}}active{{/isactive}}" href="#" id="moremenu-dropdown-{{moremenuid}}" role="{{#istablist}}tab{{/istablist}}{{^istablist}}menuitem{{/istablist}}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="-1">
-                {{#str}}moremenu, core{{/str}}
-            </a>
-            <ul class="dropdown-menu dropdown-menu-left" data-region="moredropdown" aria-labelledby="moremenu-dropdown-{{moremenuid}}" role="menu">
-            </ul>
-        </li>
     </ul>
 </nav>
 {{#js}}

--- a/govuk/templates/theme_govuk/moremenu_children.mustache
+++ b/govuk/templates/theme_govuk/moremenu_children.mustache
@@ -1,0 +1,60 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/moremenu_children
+
+    The More menu children
+
+    Example context (json):
+    {
+        "divider": "",
+        "haschildren": "",
+        "moremenuid": "614c104dbacfa",
+        "text": "Moodle community",
+        "children": "",
+        "title": "Moodle community",
+        "url": "https://moodle.org"
+    }
+}}
+{{^haschildren}}
+    <li data-key="{{key}}" class="govuk-service-navigation__item {{#isactive}}govuk-service-navigation__item--active{{/isactive}}" role="none" data-forceintomoremenu="{{#forceintomoremenu}}true{{/forceintomoremenu}}{{^forceintomoremenu}}false{{/forceintomoremenu}}">
+        {{^istablist}}
+            {{#is_action_link}}
+                <a role="menuitem" class="govuk-service-navigation__link {{#classes}}{{.}} {{/classes}}" {{#actionattributes}}{{name}}="{{value}}" {{/actionattributes}} href="{{{url}}}{{{action}}}"
+                    {{#title}}title="{{.}}"{{/title}}
+                    data-disableactive="true" tabindex="-1"
+                >
+                    {{{text}}}
+                </a>
+                {{#action_link_actions}}
+                    {{> core/actions }}
+                {{/action_link_actions}}
+            {{/is_action_link}}
+            {{^is_action_link}}
+                <a role="menuitem" class="govuk-service-navigation__link {{#isactive}}govuk-service-navigation__item--active{{/isactive}} {{#classes}}{{.}} {{/classes}}"
+                    href="{{{url}}}{{{action}}}"
+                    {{#title}}title="{{.}}"{{/title}}
+                    {{#isactive}}aria-current="true"{{/isactive}}
+                    data-disableactive="true"
+                    {{^isactive}}tabindex="-1"{{/isactive}}
+                >
+                    {{{text}}}
+                </a>
+            {{/is_action_link}}
+        {{/istablist}}
+    </li>
+{{/haschildren}}

--- a/govuk/templates/theme_govuk/navbar.mustache
+++ b/govuk/templates/theme_govuk/navbar.mustache
@@ -75,8 +75,7 @@
     </div>
   </div>
 </header>
-<div class="govuk-service-navigation"
-  data-module="govuk-service-navigation">
+<div class="govuk-service-navigation" data-module="govuk-service-navigation">
   <div class="govuk-width-container">
     <div class="govuk-service-navigation__container">
         {{#primarymoremenu}}


### PR DESCRIPTION
Also fixed a bug that was causing the "active" tab style not to show 

Before 
![image](https://github.com/user-attachments/assets/3784144f-035f-4f90-a5df-513ce3daa6c9)

After
![image](https://github.com/user-attachments/assets/d43d90b0-ffb9-4ab2-9701-d68367d1c1cd)