### PR TITLE
SWIP-642 - Manage courses button styles

### DIFF
--- a/govuk/templates/my/dropdown.mustache
+++ b/govuk/templates/my/dropdown.mustache
@@ -1,0 +1,47 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core_my/dropdown
+
+    Simple dropdown for the my/courses page.
+
+    Example context (json):
+    {
+        "newcourseurl": "https://moodle.test/course/edit.php?category=1",
+        "manageurl": "https://moodle.test/course/management.php?categoryid=1",
+        "courserequesturl": "https://moodle.test/course/request.php?categoryid=1"
+    }
+}}
+<div class="btn-group{{#manageurl}} course-manage{{/manageurl}}{{#courserequesturl}} course-request{{/courserequesturl}}">
+    <div class="my-action-buttons my-action-buttons-right">
+        {{#manageurl}}
+            <form action="{{manageurl}}" method="post" id="managecoursesform">
+                <button type="submit" class="govuk-button govuk-button--secondary m-1 w-100">{{#str}} managecourses {{/str}}</button>
+            </form>
+        {{/manageurl}}
+        {{#newcourseurl}}
+            <form action="{{newcourseurl}}" method="post" id="newcourseform">
+                <button type="submit" class="govuk-button govuk-button--primary m-1 w-100">{{#str}} createcourse, block_myoverview {{/str}}</button>
+            </form>
+        {{/newcourseurl}}
+        {{#courserequesturl}}
+            <form action="{{courserequesturl}}" method="post" id="courserequestform">
+                <button type="submit" class="btn btn-primary m-1 w-100">{{#str}} requestcourse {{/str}}</button>
+            </form>
+        {{/courserequesturl}}
+    </div>
+</div>


### PR DESCRIPTION
- Set the class for the Manage Courses button to be `govuk-button--secondary`
- Sets the class for the Create Course button to be `govuk-button--primary`. Styling this button was previously achieved by overwritting styles with CSS so this change via the template is a bit cleaner.