### PR TITLE
SWIP-1044 Remove breadcrumb on course pages

### DIFF
--- a/govuk/renderers.php
+++ b/govuk/renderers.php
@@ -67,4 +67,12 @@ class theme_govuk_core_renderer extends core_renderer
         }
         return $firstview;
     }
+
+    /** Hide breadcrumbs on pages within a course */
+    public function navbar(): string {
+        if ($this->page->context && $this->page->context->get_course_context(false)) {
+            return '';
+        }
+        return parent::navbar();
+    }
 }


### PR DESCRIPTION
Changes for [SWIP-1044](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1044) to remove the breadcrumb element on pages within a course. Screenshots available on the ticket.