### PR TITLE
SWIP-1043 Child swpdp theme support

### DIFF
--- a/govuk/scss/govuk.scss
+++ b/govuk/scss/govuk.scss
@@ -6,7 +6,7 @@ html body {
   height: auto;
 }
 
-.btn-primary {
+.btn.btn-primary {
   // This is the Moodle class
   @extend .govuk-button; // extends this class with the styles from govuk-button
 }


### PR DESCRIPTION
Needed for the primary button styles to apply in the govuk swpdp child theme which is stored in the social-work-induction-programme-digital-service repo. As part of [SWIP-1043](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1043).

[SWIP-1043]: https://dfedigital.atlassian.net/browse/SWIP-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ