### PR TITLE
SWIP-1109 Format empty db activity page

### DIFF
--- a/govuk/config.php
+++ b/govuk/config.php
@@ -27,8 +27,15 @@ defined('MOODLE_INTERNAL') || die();
 
 $THEME->name = 'govuk';
 $THEME->parents = ['boost'];
-$THEME->sheets = ['govuk', 'service-header'];
+$THEME->sheets = ['service-header'];
 $THEME->rendererfactory = 'theme_overridden_renderer_factory';
+
+// Use Moodle’s SCSS pipeline
+$THEME->scss = function($theme) {
+    return theme_govuk_get_main_scss_content($theme);
+};
+$THEME->prescsscallback   = 'theme_govuk_get_pre_scss';
+$THEME->extrascsscallback = 'theme_govuk_get_extra_scss';
 
 $THEME->layouts = [
     'standard' => [

--- a/govuk/lib.php
+++ b/govuk/lib.php
@@ -24,3 +24,34 @@
 
 // This line protects the file from being accessed by a URL directly.
 defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Main SCSS - add GOV.UK to boost
+ */
+function theme_govuk_get_main_scss_content($theme): string {
+    $scss = theme_boost_get_main_scss_content($theme);
+
+    $govuk = @file_get_contents(__DIR__ . '/scss/govuk.scss') ?: '';
+    return $scss . "\n" . $govuk;
+}
+
+/**
+ * SCSS to prepend (variables before Bootstrap/GOV.UK compile)
+ */
+function theme_govuk_get_pre_scss($theme): string {
+    $scss = theme_boost_get_pre_scss($theme);
+    // E.g. 
+    // $scss .= "\n" . '$govuk-assets-path: "/theme/image.php/govuk/theme/1/";';
+    return $scss;
+}
+
+/**
+ * SCSS to append (after main bundle)
+ */
+function theme_govuk_get_extra_scss($theme): string {
+    $scss = theme_boost_get_extra_scss($theme);
+    // E.g.
+    // $extra = @file_get_contents(__DIR__ . '/scss/extra.scss') ?: '';
+    // return $scss . "\n" . $extra;
+    return $scss;
+}

--- a/govuk/renderers.php
+++ b/govuk/renderers.php
@@ -68,18 +68,6 @@ class theme_govuk_core_renderer extends core_renderer
         return $firstview;
     }
 
-    /** Hide breadcrumbs on pages within a course */
-    public function navbar(): string
-    {
-        if (
-            $this->page->context &&
-            $this->page->context->get_course_context(false)
-        ) {
-            return '';
-        }
-        return parent::navbar();
-    }
-
     /**
      * Override to change content used to render the sticky footer template
      * on the add entry page for database activities (mod/data/edit.php)

--- a/govuk/templates/core/activity_header.mustache
+++ b/govuk/templates/core/activity_header.mustache
@@ -1,0 +1,88 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/activity_header
+
+    Activity header template.
+
+    Context variables required for this template:
+    * title - The title of the activity module
+    * description - The intro for the module
+    * completion - The completion info if available for the the module as acquired via the activity_information method
+    * additional_items - Any additional URL select navigation that needs to show up in the header
+
+    Example context (json):
+    {
+        "title": "Assignment 1",
+        "description": "The assignment does something",
+        "completion": "<div class='activitycompletion'>Some activity completion criteria</div>",
+        "additional_items": {
+            "id": "url_select_test",
+            "action": "https://example.com/post",
+            "formid": "url_select_form",
+            "sesskey": "sesskey",
+            "label": "core/url_select",
+            "helpicon": {
+                "title": "Help with something",
+                "text": "Help with something",
+                "url": "http://example.org/help",
+                "linktext": "",
+                "icon":{
+                    "extraclasses": "",
+                    "attributes": [
+                        {"name": "src", "value": "../../../pix/help.svg"},
+                        {"name": "alt", "value": "Help icon"}
+                    ]
+                }
+            },
+            "showbutton": "Go",
+            "options": [{
+                "name": "Group 1", "isgroup": true, "options":
+                [
+                    {"name": "Item 1", "isgroup": false, "value": "1"},
+                    {"name": "Item 2", "isgroup": false, "value": "2"}
+                ]},
+                {"name": "Group 2", "isgroup": true, "options":
+                [
+                    {"name": "Item 3", "isgroup": false, "value": "3"},
+                    {"name": "Item 4", "isgroup": false, "value": "4"}
+                ]}],
+            "disabled": false,
+            "title": "Some cool title"
+        }
+    }
+}}
+<span id="maincontent"></span>
+{{#title}}
+    <h2>{{{title}}}</h2>
+{{/title}}
+<div class="govuk-body" data-for="page-activity-header">{{!
+    }}{{#completion}}
+        <span class="sr-only">{{#str}} overallaggregation, completion {{/str}}</span>
+        {{{completion}}}
+    {{/completion}}
+    {{#description}}
+        <div class="activity-description" id="intro">
+            {{{description}}}
+        </div>
+    {{/description}}{{!
+}}</div>
+{{#additional_items}}
+    <nav aria-label="{{#str}} additionalcustomnav, core {{/str}}">
+        {{> core/url_select}}
+    </nav>
+{{/additional_items}}


### PR DESCRIPTION
Changes as part of [SWIP-1109](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1109):

-styling of activity descriptions component as per GDS

-also included change to move the logic that hides breadcrumbs on course pages out of the general govuk theme

-move from specified css sheets to using the scss file itself and the Moodle in-built compiler (TBC if we keep this in; if we do, to also tweak the Github workflow to remove the scss processing step and update the readme local dev instructions)